### PR TITLE
chore: added go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/gomarkdown/mdtohtml
+
+go 1.18
+
+require github.com/gomarkdown/markdown v0.0.0-20220627144906-e9a81102ebeb

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/gomarkdown/markdown v0.0.0-20220627144906-e9a81102ebeb h1:5b/eFaSaKPFG9ygDBaPKkydKU5nFJYk08g9jPIVogMg=
+github.com/gomarkdown/markdown v0.0.0-20220627144906-e9a81102ebeb/go.mod h1:JDGcbDT52eL4fju3sZ4TeHGsQwhG9nbDV21aMyhwPoA=


### PR DESCRIPTION
`go get` requires a go module

```
Run go get -u github.com/gomarkdown/mdtohtml
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation
	or run 'go help get' or 'go help install'.
Error: Process completed with exit code 1.
```